### PR TITLE
Prepare for 2.0.3 development

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -51,7 +51,7 @@ afterEvaluate {
                 artifact tasks.androidSourcesJar
                 groupId = 'com.lisb.android.mediashrink'
                 artifactId = 'mediashrink'
-                version = '2.0.2'
+                version = '2.0.3-SNAPSHOT'
             }
         }
     }


### PR DESCRIPTION
2.0.3 開発にむけ version を 2.0.3-SNAPSHOT に更新。
JCenter に依存している関係でビルドが通らない問題は別のPRで対応。