### PR TITLE
利用していない権限を削除

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    
     <application
         android:allowBackup="false"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
`WRITE_EXTERNAL_STORAGE` は利用してないので権限を削除